### PR TITLE
Add RPCS3 support for PS3

### DIFF
--- a/Contents/Code/archer_dict.py
+++ b/Contents/Code/archer_dict.py
@@ -104,6 +104,8 @@ dDefaultSettings = {
     
     'app_directory_retroarch' : '',
     'app_binary_retroarch' : 'retroarch',
+    'app_directory_rpcs3' : '',
+    'app_binary_rpcs3' : 'rpcs3',
 	
 	#these are needed to ensure we don't scan any unsupported systems
 	'scanner_3do_interactive_multiplayer' : 'True',
@@ -194,6 +196,7 @@ dDefaultSettings = {
 	'scanner_snk_neo_geo_pocket_color' : 'True',
 	'scanner_sony_playstation' : 'True',
 	'scanner_sony_playstation_2' : 'True',
+	'scanner_sony_playstation_3' : 'True',
 	'scanner_sony_psp' : 'True',
 	'scanner_star_trek_voyager_engine' : 'True',
 	'scanner_super_nintendo_entertainment_system' : 'True',
@@ -4348,9 +4351,14 @@ dPlatformMapping = {
 			'thegamesdb' : 12
 			},
         'libraryType' : 'Games',
-		'romExtensions' : [],
-		'romType' : 0,
-		'multiDisk' : False
+		'romExtensions' : ['bin'],
+		'romType' : 1,
+		'multiDisk' : False,
+        'emulators' : {
+            0 : 'rpcs3', #agent enums to emulator name
+            1 : 'rpcs3',
+            'rpcs3' : {}
+            }
 		},
     'Sony PlayStation 4' : { 
 		'systemNames' : ['Sony PlayStation 4', 'PlayStation 4', 'PS4'],

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -39,8 +39,10 @@
   { "id":"PLEX_URL",                  "label":"ADVANCED SETTINGS\n_____________________________________________________________________________________\nPLEX|Server URL",    "type":"text",    "default":"http://localhost:32400"  },
   { "id":"PLEX_TOKEN",                "label":"PLEX|Server token",    "type":"text",    "option":"hidden",     "default":"",		"secure":"true"  },
 
-  { "id":"app_directory_retroarch",   "label":"APPLICAITON|DIRECTORY|RetroArch",    "type":"text",    "default":""  },
-  { "id":"app_binary_retroarch",      "label":"APPLICAITON|BINARY|RetroArch",    "type":"text",    "default":"retroarch"  },
+  { "id":"app_directory_retroarch",   "label":"APPLICATION|DIRECTORY|RetroArch",    "type":"text",    "default":""  },
+  { "id":"app_binary_retroarch",      "label":"APPLICATION|BINARY|RetroArch",    "type":"text",    "default":"retroarch"  },
+  { "id":"app_directory_rpcs3",       "label":"APPLICATION|DIRECTORY|RPCS3",    "type":"text",    "default":""  },
+  { "id":"app_binary_rpcs3",          "label":"APPLICATION|BINARY|RPCS3",    "type":"text",    "default":"rpcs3"  },
 
   { "id":"scanner_3do_interactive_multiplayer",           "label":"SCANNER|3DO Interactive Multiplayer",    "type":"bool",    "default":"True"  },
   { "id":"scanner_amstrad_cpc",                           "label":"SCANNER|Amstrad CPC",    "type":"bool",    "default":"True"  },
@@ -130,6 +132,7 @@
   { "id":"scanner_snk_neo_geo_pocket_color",              "label":"SCANNER|SNK Neo Geo Pocket Color",    "type":"bool",    "default":"True"  },
   { "id":"scanner_sony_playstation",                      "label":"SCANNER|Sony PlayStation",    "type":"bool",    "default":"True"  },
   { "id":"scanner_sony_playstation_2",                    "label":"SCANNER|Sony PlayStation 2",    "type":"bool",    "default":"True"  },
+  { "id":"scanner_sony_playstation_3",                    "label":"SCANNER|Sony PlayStation 3",    "type":"bool",    "default":"True"  },
   { "id":"scanner_sony_psp",                              "label":"SCANNER|Sony PSP",    "type":"bool",    "default":"True"  },
   { "id":"scanner_star_trek_voyager_engine",              "label":"SCANNER|Star Trek Voyager Engine",    "type":"bool",    "default":"True"  },
   { "id":"scanner_super_nintendo_entertainment_system",   "label":"SCANNER|Super Nintendo Entertainment System",    "type":"bool",    "default":"True"  },
@@ -228,6 +231,7 @@
   { "id":"emulator_snk_neo_geo_pocket_color",             "label":"EMULATOR|SNK Neo Geo Pocket Color",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },
   { "id":"emulator_sony_playstation",                     "label":"EMULATOR|Sony PlayStation",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },
   { "id":"emulator_sony_playstation_2",                   "label":"EMULATOR|Sony PlayStation 2",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },
+  { "id":"emulator_sony_playstation_3",                   "label":"EMULATOR|Sony PlayStation 3",    "type": "enum",    "values": [ "default", "RPCS3" ],    "default": "default"  },
   { "id":"emulator_sony_psp",                             "label":"EMULATOR|Sony PSP",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },
   { "id":"emulator_star_trek_voyager_engine",             "label":"EMULATOR|Star Trek Voyager Engine",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },
   { "id":"emulator_super_nintendo_entertainment_system",  "label":"EMULATOR|Super Nintendo Entertainment System",    "type": "enum",    "values": [ "default", "Retroarch" ],    "default": "default"  },

--- a/Contents/PrefsToAdd.json
+++ b/Contents/PrefsToAdd.json
@@ -37,11 +37,9 @@
   { "id":"sUpdateBranch",             "label":"-UPDATER|Branch",    "type":"text",    "default":"main"  },
   { "id":"sUpdateAuto",               "label":"-UPDATER|Automatic update (during scanning)",    "type":"bool",    "default":"False"  },
 
-  { "id":"app_directory_rpcs3",       "label":"APPLICAITON|DIRECTORY|RPCS3",    "type":"text",    "default":""  },
-  { "id":"app_binary_rpcs3",          "label":"APPLICAITON|BINARY|RPCS3",    "type":"text",    "default":"rpcs3"  },
-  { "id":"app_directory_xemu",        "label":"APPLICAITON|DIRECTORY|Xemu",    "type":"text",    "default":""  },
-  { "id":"app_binary_xemu",           "label":"APPLICAITON|BINARY|Xemu",    "type":"text",    "default":"xemu"  },
-  { "id":"app_directory_xenia",       "label":"APPLICAITON|DIRECTORY|Xenia",    "type":"text",    "default":""  },
-  { "id":"app_binary_xenia",          "label":"APPLICAITON|BINARY|Xenia",    "type":"text",    "default":"xenia"  }
+  { "id":"app_directory_xemu",        "label":"APPLICATION|DIRECTORY|Xemu",    "type":"text",    "default":""  },
+  { "id":"app_binary_xemu",           "label":"APPLICATION|BINARY|Xemu",    "type":"text",    "default":"xemu"  },
+  { "id":"app_directory_xenia",       "label":"APPLICATION|DIRECTORY|Xenia",    "type":"text",    "default":""  },
+  { "id":"app_binary_xenia",          "label":"APPLICATION|BINARY|Xenia",    "type":"text",    "default":"xenia"  }
 
 ]

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Ubuntu
       - `File` - `contains` - `com.github.agents.retroarcher.retroarcher`
     - Arguments
       - Playback Start
-	    - `--launch --user {user} --device {device} --platform {platform} --product {product} --player {player} --ip_address {ip_address} --file {file}`
+	    - `--launch --user {user} --user_id {user_id} --device {device} --platform {platform} --product {product} --player {player} --ip_address {ip_address} --file {file}`
 - Notes
   - In the future I will try to automate this with tautulli python api (Issue #48).
 


### PR DESCRIPTION
Closes #32 

retroarcher.py
-pass clientUserId to launcher (requires update to Wiki instructions for setting up Tautulli)
-set emulator core to nothing (prevents problems with dictionary when retroarch is not the emulator)
-process plex user id and make it 8 digits so can be used in RPCS3
-removed some commented out code
-adjust scanning for playstation 3 (game naming is unique and based on an upper level folder name)
-fixed issue if rom extensions were not lowercase

archer_dict.py
-add settings for rpcs3 and playstation 3
-adjust values for playstation 3 platform map

DefaultPrefs.json
-fixed typo
-add settings for rpcs3 and playstation 3

PrefsToAdd.json
-removed settings for rpcs3
-fixed typo

README.md
-add --user_id parameter to tautulli configuration section