### PR TITLE
docs: fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,12 @@ build:
   os: ubuntu-20.04
   tools:
     python: "2.7"
+  jobs:
+    pre_build:
+      - python ./scripts/build_plist.py
+    post_build:
+      - rstcheck -r .  # lint rst files
+      # - rstfmt --check --diff -w 120 .  # check rst formatting
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -25,4 +31,3 @@ python:
   install:
     - requirements: requirements.txt  # plugin requirements
     - requirements: requirements-dev.txt  # docs requirements
-  system_packages: true

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,11 @@
+# configuration file for rstcheck, an rst linting tool
+# https://rstcheck.readthedocs.io/en/latest/usage/config
+
+[rstcheck]
+ignore_directives =
+    automodule,
+    include,
+    mdinclude,
+    todo,
+ignore_roles =
+    modname,

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ About
 RetroArcher-plex is plug-in for Plex Media Player that connects plex to RetroArcher.
 
 .. Note:: This project is under development and not useful at this time. RetroArcher is in the process of being
-   rewritten. You can follow progress on the `RetroArcher GitHub <https://github.com/LizardByte/RetroArcher>`_.
+   rewritten. You can follow progress on the `RetroArcher GitHub <https://github.com/LizardByte/RetroArcher>`__.
 
 Integrations
 ------------

--- a/docs/source/contributing/build.rst
+++ b/docs/source/contributing/build.rst
@@ -7,7 +7,7 @@ Python 2.7.
 
 Clone
 -----
-Ensure `git <https://git-scm.com/>`_ is installed and run the following:
+Ensure `git <https://git-scm.com/>`__ is installed and run the following:
 
    .. code-block:: bash
 

--- a/docs/source/contributing/contributing.rst
+++ b/docs/source/contributing/contributing.rst
@@ -4,4 +4,4 @@ Contributing
 ============
 
 Read our contribution guide in our organization level
-`docs <https://lizardbyte.readthedocs.io/en/latest/developers/contributing.html>`_.
+`docs <https://lizardbyte.readthedocs.io/en/latest/developers/contributing.html>`__.

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -7,7 +7,7 @@ Unless otherwise specified the ``requirements.txt`` file is located in the ``scr
 
 Flake8
 ------
-RetroArcher uses `Flake8 <https://pypi.org/project/flake8/>`_ for enforcing consistent code styling. Flake is included
+RetroArcher uses `Flake8 <https://pypi.org/project/flake8/>`__ for enforcing consistent code styling. Flake8 is included
 in the ``requirements.txt``.
 
 The config file for flake8 is ``.flake8``. This is already included in the root of the repo and should not be modified.
@@ -19,10 +19,10 @@ Test with Flake8
 
 Sphinx
 ------
-RetroArcher uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_ for documentation building. Sphinx is included
+RetroArcher uses `Sphinx <https://www.sphinx-doc.org/en/master/>`__ for documentation building. Sphinx is included
 in the ``requirements.txt``.
 
-RetroArcher follows `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ styling and formatting in
+RetroArcher follows `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`__ styling and formatting in
 docstrings. This will be tested when building the docs.
 
 The config file for Sphinx is ``docs/source/conf.py``. This is already included in the root of the repo and should not
@@ -45,7 +45,7 @@ pytest
 ------
 .. Todo:: PyTest is not yet implemented.
 
-RetroArcher uses `pytest <https://pypi.org/project/pytest/>`_ for unit testing. pytest is included in the
+RetroArcher uses `pytest <https://pypi.org/project/pytest/>`__ for unit testing. pytest is included in the
 ``requirements.txt``.
 
 No config is required for pytest.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
 :github_url: https://github.com/LizardByte/RetroArcher/tree/nightly/docs/source/index.rst
 
-RetroArcher has this documentation hosted on `Read the Docs <http://retroarcher.readthedocs.io/>`_.
+RetroArcher has this documentation hosted on `Read the Docs <http://retroarcher.readthedocs.io/>`__.
 
 Table of Contents
 =================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ m2r2==0.3.2;python_version<"3"
 git+https://github.com/LizardByte/plexhints.git#egg=plexhints  # type hinting library for plex development
 pytest==4.6.11;python_version<"3"
 requests==2.27.1;python_version<"3"
+rstcheck==3.5.0;python_version<"3"
 Sphinx==1.8.6;python_version<"3"
 sphinx-rtd-theme==1.2.0;python_version<"3"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes the readthedocs build and implements rstcheck.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
