### PR TITLE
ci: use prerelease logic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,26 +10,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
   setup_release:
     name: Setup Release
     outputs:
-      changelog_changes: ${{ steps.setup_release.outputs.changelog_changes }}
-      changelog_date: ${{ steps.setup_release.outputs.changelog_date }}
-      changelog_exists: ${{ steps.setup_release.outputs.changelog_exists }}
-      changelog_release_exists: ${{ steps.setup_release.outputs.changelog_release_exists }}
-      changelog_url: ${{ steps.setup_release.outputs.changelog_url }}
-      changelog_version: ${{ steps.setup_release.outputs.changelog_version }}
-      publish_pre_release: ${{ steps.setup_release.outputs.publish_pre_release }}
       publish_release: ${{ steps.setup_release.outputs.publish_release }}
-      publish_stable_release: ${{ steps.setup_release.outputs.publish_stable_release }}
-      release_body: ${{ steps.setup_release.outputs.release_body }}
       release_build: ${{ steps.setup_release.outputs.release_build }}
       release_commit: ${{ steps.setup_release.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
     runs-on: ubuntu-latest
@@ -39,7 +29,7 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2023.1210.1904
+        uses: LizardByte/setup-release-action@v2024.520.193857
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,7 +45,7 @@ jobs:
           path: RetroArcher-plex.bundle
 
       - name: Set up Python
-        uses: LizardByte/setup-python-action@v2023.1211.161304
+        uses: LizardByte/setup-python-action@v2024.515.10401
         with:
           python-version: '2.7'
 
@@ -96,10 +86,13 @@ jobs:
             "-xr!plexhints*" \
             "-xr!RetroArcher-plex.bundle/.*" \
             "-xr!RetroArcher-plex.bundle/cache.sqlite" \
+            "-xr!RetroArcher-plex.bundle/codecov.yml" \
+            "-xr!RetroArcher-plex.bundle/crowdin.yml" \
             "-xr!RetroArcher-plex.bundle/DOCKER_README.md" \
             "-xr!RetroArcher-plex.bundle/Dockerfile" \
             "-xr!RetroArcher-plex.bundle/docs" \
             "-xr!RetroArcher-plex.bundle/scripts" \
+            "-xr!RetroArcher-plex.bundle/tests" \
             a "./RetroArcher-plex.bundle.zip" "RetroArcher-plex.bundle"
 
           mkdir artifacts
@@ -115,14 +108,12 @@ jobs:
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' }}
-        uses: LizardByte/create-release-action@v2023.1210.832
+        uses: LizardByte/create-release-action@v2024.520.193838
         with:
           allowUpdates: true
-          body: ''
           discussionCategory: announcements
           generateReleaseNotes: true
           name: ${{ needs.setup_release.outputs.release_tag }}
-          # use pre-release for now
-          prerelease: true  # ${{ needs.setup_release.outputs.publish_pre_release }}
+          prerelease: true
           tag: ${{ needs.setup_release.outputs.release_tag }}
           token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use new prerelease logic.
- Bump setup-python action.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
